### PR TITLE
Fix Xero's Grave Logic for BACKGROUNDPOGOS

### DIFF
--- a/LoreRandomizer/Resources/Logic/PointOfInterestLogic.json
+++ b/LoreRandomizer/Resources/Logic/PointOfInterestLogic.json
@@ -49,7 +49,7 @@
   },
   {
     "name": "Xero_Grave",
-    "logic": "(READ ? ANY) + (((RestingGrounds_02[left1] | RestingGrounds_02[right1] | RestingGrounds_02[bot1]) + (ENEMYPOGOS | RIGHTCLAW | LEFTCLAW | WINGS | RIGHTSUPERDASH)) | RestingGrounds_02[top1])"
+    "logic": "(READ ? ANY) + (RestingGrounds_02[top1] | RestingGrounds_02 + (ANYCLAW | WINGS | RIGHTSUPERDASH | BACKGROUNDPOGOS))"
   },
   {
     "name": "Elder_Hu_Grave",


### PR DESCRIPTION
I took the logic from the Randomizer mod for accessing Xero and updated the Xero_Grave rule accordingly - it should make those locations match a bit better, and swaps out ENEMYPOGOS for BACKGROUNDPOGOS since there aren't any enemies in RestingGrounds_02 but there is a handy background object that'll do the trick.